### PR TITLE
Expose port 4180 inside the docker container

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
       versions:
        - trusty
   galaxy_tags:
-    - docker
-    - ubuntu
-    - oauth2_proxy
+    - 'docker'
+    - 'ubuntu'
+    - 'oauth2_proxy'
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     image: 'skippy/oauth2_proxy'
     name: '{{ docker_oauth2_proxy_container_name }}'
     ports: '{{ docker_oauth2_proxy_published_port }}:4180'
+    expose: '4180'
     command: '{{ docker_oauth2_proxy_command }}'
     state: 'started'
     restart_policy: 'always'


### PR DESCRIPTION
Ansible does a strange thing with the `publish` parameter. If a port inside the docker container has not been explicitly `EXPOSE`d, the `publish` parameter will ignore this port.

This contradicts the expectation set by the docker cli.

The docker cli, in these circumstances, expose the port since this is implied by the caller.
