### PR TITLE
Allow a caller to mount volumes to the docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ docker_oauth2_proxy_container_name: 'oauth2proxy'
 # oauth2-proxy host port
 docker_oauth2_proxy_published_port: '4180'
 
+# Any files/directories that need mounting inside the docker container
+docker_oauth2_volumes: []
+
 # oauth2-proxy command line arguments
 docker_oauth2_proxy_command: >-
   --upstream="http://127.0.0.1:8080/"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ docker_oauth2_proxy_container_name: 'oauth2proxy'
 # oauth2-proxy host port
 docker_oauth2_proxy_published_port: '4180'
 
+# Any files/directories that need mounting inside the docker container
+docker_oauth2_volumes: []
+
 # oauth2-proxy command line arguments
 docker_oauth2_proxy_command: >-
   --upstream="http://127.0.0.1:8080/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
   docker:
     image: 'skippy/oauth2_proxy'
     name: '{{ docker_oauth2_proxy_container_name }}'
+    volumes: '{{ docker_oauth2_volumes }}'
     ports: '{{ docker_oauth2_proxy_published_port }}:4180'
     expose: '4180'
     command: '{{ docker_oauth2_proxy_command }}'


### PR DESCRIPTION
This allows, for example:

``` yaml
docker_oauth2_volumes:
  - "/host/path/to/authorized_users.txt:/authorized_users.txt:ro"
```

Which could then be used like:

``` yaml
docker_oauth2_proxy_command: >-
  ...
  --authenticated-emails-file=/authorized_users.txt
  ...
```

Which would instruct oauth2_proxy to only authorize valid emails in the `authorized_users.txt` file.
